### PR TITLE
Urgency level feature testing

### DIFF
--- a/app/src/main/java/com/example/taskly/MainActivity.java
+++ b/app/src/main/java/com/example/taskly/MainActivity.java
@@ -16,6 +16,8 @@ import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.EditText;
 import android.widget.ListView;
+import android.widget.RadioButton;
+import android.widget.RadioGroup;
 import android.widget.TextView;
 
 import com.example.taskly.db.TaskContract;
@@ -71,13 +73,19 @@ public class MainActivity extends AppCompatActivity {
                                 EditText taskDueDate = customLayout.findViewById(R.id.editText_dateDue);
                                 EditText taskDueTime = customLayout.findViewById(R.id.editText_timeDue);
 
+                                RadioGroup taskUrgencyGroup = customLayout.findViewById(R.id.radioGroup_urgency_levels);
+                                int taskUrgencyId = taskUrgencyGroup.getCheckedRadioButtonId();
+                                RadioButton taskUrgency = customLayout.findViewById(taskUrgencyId);
+
                                 String task = String.valueOf(taskInfo.getText());
                                 String dueDate = String.valueOf(taskDueDate.getText());
                                 String dueTime = String.valueOf(taskDueTime.getText());
+                                String urgency = taskUrgency.getText().toString();
 
                                 Log.d(TAG, "Task to add: " + task);
                                 Log.d(TAG, "Task due date: " + dueDate);
                                 Log.d(TAG, "Task due time: " + dueTime);
+                                Log.d(TAG, "Task urgency: " + urgency);
 
                                 SQLiteDatabase db = mHelper.getWritableDatabase();
                                 ContentValues values = new ContentValues();

--- a/app/src/main/java/com/example/taskly/MainActivity.java
+++ b/app/src/main/java/com/example/taskly/MainActivity.java
@@ -9,9 +9,6 @@ import android.content.DialogInterface;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Bundle;
-import android.text.Editable;
-import android.text.TextUtils;
-import android.text.TextWatcher;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -26,7 +23,6 @@ import android.widget.TextView;
 import com.example.taskly.db.TaskContract;
 import com.example.taskly.db.TaskDbHelper;
 
-import org.w3c.dom.Text;
 
 import java.util.ArrayList;
 
@@ -64,7 +60,6 @@ public class MainActivity extends AppCompatActivity {
         switch (item.getItemId()) {
             case R.id.action_add_task:
                 Log.d(TAG, "Adding a new task");
-
 
                 final View customLayout = getLayoutInflater().inflate(R.layout.activity_add_task, null);
                 final AlertDialog dialog = new AlertDialog.Builder(this)
@@ -113,11 +108,7 @@ public class MainActivity extends AppCompatActivity {
                 // Initially disabled the button
                 ((AlertDialog) dialog).getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
 
-                EditText addedTaskInfo = (EditText)customLayout.findViewById(R.id.editText_taskInfo);
                 RadioGroup radioGroupUrgencies = (RadioGroup)customLayout.findViewById(R.id.radioGroup_urgency_levels);
-                RadioButton radioButtonUrgency = (RadioButton)customLayout.findViewById(radioGroupUrgencies.getCheckedRadioButtonId());
-
-                Log.d(TAG, "Radio Button ID is: " + radioButtonUrgency);
 
                 radioGroupUrgencies.setOnCheckedChangeListener(new RadioGroup.OnCheckedChangeListener() {
                     @Override
@@ -125,7 +116,6 @@ public class MainActivity extends AppCompatActivity {
                         ((AlertDialog) dialog).getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(true);
                     }
                 });
-
 
                 return true;
             default:

--- a/app/src/main/java/com/example/taskly/MainActivity.java
+++ b/app/src/main/java/com/example/taskly/MainActivity.java
@@ -92,6 +92,7 @@ public class MainActivity extends AppCompatActivity {
                                 values.put(TaskContract.TaskEntry.COL_TASK_TITLE, task);
                                 values.put(TaskContract.TaskEntry.COL_TASK_DATE, dueDate);
                                 values.put(TaskContract.TaskEntry.COL_TASK_TIME, dueTime);
+                                values.put(TaskContract.TaskEntry.COL_TASK_URGENCY, urgency);
                                 db.insertWithOnConflict(TaskContract.TaskEntry.TABLE,
                                         null,
                                         values,
@@ -117,7 +118,7 @@ public class MainActivity extends AppCompatActivity {
 
         Cursor cursor = db.query(
                 TaskContract.TaskEntry.TABLE,
-                new String[] {TaskContract.TaskEntry._ID, TaskContract.TaskEntry.COL_TASK_TITLE, TaskContract.TaskEntry.COL_TASK_DATE, TaskContract.TaskEntry.COL_TASK_TIME},
+                new String[] {TaskContract.TaskEntry._ID, TaskContract.TaskEntry.COL_TASK_TITLE, TaskContract.TaskEntry.COL_TASK_DATE, TaskContract.TaskEntry.COL_TASK_TIME, TaskContract.TaskEntry.COL_TASK_URGENCY},
                 null,
                 null,
                 null,
@@ -135,7 +136,10 @@ public class MainActivity extends AppCompatActivity {
             int idxDueTime = cursor.getColumnIndex(TaskContract.TaskEntry.COL_TASK_TIME);
             String dueTimeOfTask = cursor.getString((idxDueTime));
 
-            Task currentTask = new Task(titleOfTask, dueDateOfTask, dueTimeOfTask);
+            int idxUrgency = cursor.getColumnIndex(TaskContract.TaskEntry.COL_TASK_URGENCY);
+            String urgencyOfTask = cursor.getString((idxUrgency));
+
+            Task currentTask = new Task(titleOfTask, dueDateOfTask, dueTimeOfTask, urgencyOfTask);
 
             taskList.add(currentTask);
             Log.d(
@@ -145,7 +149,10 @@ public class MainActivity extends AppCompatActivity {
                             " Due on: " +
                             currentTask.getTaskDueDate() +
                             " At: " +
-                            currentTask.getTaskDueTime());
+                            currentTask.getTaskDueTime() +
+                            " With Urgency: " +
+                            currentTask.getTaskUrgency()
+                    );
         }
 
         if (mAdapter == null) {

--- a/app/src/main/java/com/example/taskly/MainActivity.java
+++ b/app/src/main/java/com/example/taskly/MainActivity.java
@@ -9,6 +9,9 @@ import android.content.DialogInterface;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextUtils;
+import android.text.TextWatcher;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -22,6 +25,8 @@ import android.widget.TextView;
 
 import com.example.taskly.db.TaskContract;
 import com.example.taskly.db.TaskDbHelper;
+
+import org.w3c.dom.Text;
 
 import java.util.ArrayList;
 
@@ -62,7 +67,7 @@ public class MainActivity extends AppCompatActivity {
 
 
                 final View customLayout = getLayoutInflater().inflate(R.layout.activity_add_task, null);
-                AlertDialog dialog = new AlertDialog.Builder(this)
+                final AlertDialog dialog = new AlertDialog.Builder(this)
                         .setTitle("Add a new task")
                         .setMessage("What do you want to do next?")
                         .setView(customLayout)
@@ -104,6 +109,23 @@ public class MainActivity extends AppCompatActivity {
                         .setNegativeButton("Cancel", null)
                         .create();
                 dialog.show();
+
+                // Initially disabled the button
+                ((AlertDialog) dialog).getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+
+                EditText addedTaskInfo = (EditText)customLayout.findViewById(R.id.editText_taskInfo);
+                RadioGroup radioGroupUrgencies = (RadioGroup)customLayout.findViewById(R.id.radioGroup_urgency_levels);
+                RadioButton radioButtonUrgency = (RadioButton)customLayout.findViewById(radioGroupUrgencies.getCheckedRadioButtonId());
+
+                Log.d(TAG, "Radio Button ID is: " + radioButtonUrgency);
+
+                radioGroupUrgencies.setOnCheckedChangeListener(new RadioGroup.OnCheckedChangeListener() {
+                    @Override
+                    public void onCheckedChanged(RadioGroup group, int checkedId) {
+                        ((AlertDialog) dialog).getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(true);
+                    }
+                });
+
 
                 return true;
             default:

--- a/app/src/main/java/com/example/taskly/Task.java
+++ b/app/src/main/java/com/example/taskly/Task.java
@@ -5,11 +5,13 @@ public class Task {
     private String taskName;
     private String taskDueDate;
     private String taskDueTime;
+    private String taskUrgency;
 
-    public Task(String taskName, String taskDueDate, String taskDueTime) {
+    public Task(String taskName, String taskDueDate, String taskDueTime, String taskUrgency) {
         this.taskName = taskName;
         this.taskDueDate = taskDueDate;
         this.taskDueTime = taskDueTime;
+        this.taskUrgency = taskUrgency;
     }
 
     public String getTaskName() {
@@ -34,5 +36,13 @@ public class Task {
 
     public void setTaskDueTime(String taskDueTime) {
         this.taskDueTime = taskDueTime;
+    }
+
+    public String getTaskUrgency() {
+        return taskUrgency;
+    }
+
+    public void setTaskUrgency(String taskUrgency) {
+        this.taskUrgency = taskUrgency;
     }
 }

--- a/app/src/main/java/com/example/taskly/TasksAdapter.java
+++ b/app/src/main/java/com/example/taskly/TasksAdapter.java
@@ -43,6 +43,9 @@ public class TasksAdapter extends ArrayAdapter<Task> {
             TextView taskDueTime = (TextView) listItem.findViewById(R.id.task_due_time);
             taskDueTime.setText(currentTask.getTaskDueTime());
 
+            TextView taskUrgency = (TextView) listItem.findViewById(R.id.task_urgency);
+            taskUrgency.setText(currentTask.getTaskUrgency());
+
             return listItem;
     }
 }

--- a/app/src/main/java/com/example/taskly/db/TaskContract.java
+++ b/app/src/main/java/com/example/taskly/db/TaskContract.java
@@ -11,5 +11,6 @@ public class TaskContract {
         public static final String COL_TASK_TITLE = "title";
         public static final String COL_TASK_DATE = "date";
         public static final String COL_TASK_TIME = "time";
+        public static final String COL_TASK_URGENCY = "urgency";
     }
 }

--- a/app/src/main/java/com/example/taskly/db/TaskDbHelper.java
+++ b/app/src/main/java/com/example/taskly/db/TaskDbHelper.java
@@ -16,7 +16,8 @@ public class TaskDbHelper extends SQLiteOpenHelper {
                 TaskContract.TaskEntry._ID + " INTEGER PRIMARY KEY AUTOINCREMENT, " +
                 TaskContract.TaskEntry.COL_TASK_TITLE + " TEXT NOT NULL, " +
                 TaskContract.TaskEntry.COL_TASK_DATE + " TEXT NOT NULL, " +
-                TaskContract.TaskEntry.COL_TASK_TIME + " TEXT NOT NULL);";
+                TaskContract.TaskEntry.COL_TASK_TIME + " TEXT NOT NULL, " +
+                TaskContract.TaskEntry.COL_TASK_URGENCY + " TEXT NOT NULL);";
         db.execSQL(createTable);
     }
 

--- a/app/src/main/res/layout/activity_add_task.xml
+++ b/app/src/main/res/layout/activity_add_task.xml
@@ -81,6 +81,7 @@
                 android:text="Urgency:" />
 
             <RadioGroup
+                android:id="@+id/radioGroup_urgency_levels"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_weight="1"

--- a/app/src/main/res/layout/activity_add_task.xml
+++ b/app/src/main/res/layout/activity_add_task.xml
@@ -62,6 +62,49 @@
                 android:layout_weight="1"
                 android:ems="10"
                 android:inputType="time" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_gravity="center"
+            android:layout_weight="1"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/textView_urgency"
+                android:layout_width="227dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:text="Urgency:" />
+
+            <RadioGroup
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:orientation="horizontal">
+
+                <RadioButton
+                    android:id="@+id/radioButton_urgency_low"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Low" />
+
+                <RadioButton
+                    android:id="@+id/radioButton_urgency_medium"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Medium" />
+
+                <RadioButton
+                    android:id="@+id/radioButton_urgency_high"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="High" />
+            </RadioGroup>
         </LinearLayout>
 
     </LinearLayout>

--- a/app/src/main/res/layout/activity_add_task.xml
+++ b/app/src/main/res/layout/activity_add_task.xml
@@ -73,7 +73,7 @@
             android:orientation="horizontal">
 
             <TextView
-                android:id="@+id/textView_urgency"
+                android:id="@+id/task_urgency"
                 android:layout_width="227dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"

--- a/app/src/main/res/layout/task_todo.xml
+++ b/app/src/main/res/layout/task_todo.xml
@@ -32,35 +32,52 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:gravity="center"
             android:orientation="horizontal">
 
             <TextView
                 android:id="@+id/task_due_date_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="Due on: " />
+                android:layout_weight="0"
+                android:text="Due on:   " />
 
             <TextView
                 android:id="@+id/task_due_date"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
+                android:layout_weight="0"
+                android:gravity="center"
                 android:text="00/00/00" />
 
             <TextView
                 android:id="@+id/task_due_time_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="At:" />
+                android:layout_weight="0"
+                android:text="  At:   " />
 
             <TextView
                 android:id="@+id/task_due_time"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
+                android:layout_weight="0"
                 android:text="00:00pm" />
+
+            <TextView
+                android:id="@+id/textView_ugency_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="0"
+                android:text="  Urgency:   " />
+
+            <TextView
+                android:id="@+id/textView_urgency"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="0"
+                android:text="Level" />
+
         </LinearLayout>
     </LinearLayout>
 

--- a/app/src/main/res/layout/task_todo.xml
+++ b/app/src/main/res/layout/task_todo.xml
@@ -65,14 +65,14 @@
                 android:text="00:00pm" />
 
             <TextView
-                android:id="@+id/textView_ugency_label"
+                android:id="@+id/task_ugency_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_weight="0"
                 android:text="  Urgency:   " />
 
             <TextView
-                android:id="@+id/textView_urgency"
+                android:id="@+id/task_urgency"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_weight="0"


### PR DESCRIPTION
Merging changes made in urgency-level-feature-testing branch which include:
- Successfully tested feature of "providing urgency levels as a required option during task creation". 
- Resolved bug with urgency level where a users could add a task without selecting an urgency level. This would cause the app to crash when trying to mark the Task as _**Done**_. Updated _adding task dialog_ to disable the **Add** button if required options have not yet been selected.
- Implemented feature within the dialog box right below the task due-time as part of the inflated custom layout. 
- Updated Sqlite Database to accept and store urgency levels.
- Updated Task data model to include urgency level during Task instantiation with setters/getters which will help with future software features previously discussed with team.

